### PR TITLE
Update uv lock file

### DIFF
--- a/.github/workflows/update-lock.yml
+++ b/.github/workflows/update-lock.yml
@@ -2,7 +2,7 @@ name: ⬆️ Update lock file
 
 on:
   schedule:
-    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
+    - cron: "0 9 * * 2" # Every Tuesday at 09:00 UTC (9 AM)
   workflow_dispatch:
 
 jobs:
@@ -31,10 +31,12 @@ jobs:
       - name: Update lock file
         id: update
         run: |
-          UPDATED=$(uv lock --upgrade 2>&1 | grep "^Updated")
-          echo "updated_output<<EOF" >> $GITHUB_OUTPUT
-          echo "$UPDATED" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          UPDATED=$(uv lock --upgrade 2>&1)
+          {
+            echo "updated_output<<EOF"
+            echo "$UPDATED"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/uv.lock
+++ b/uv.lock
@@ -583,11 +583,11 @@ wheels = [
 
 [[package]]
 name = "identify"
-version = "2.6.14"
+version = "2.6.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/c4/62963f25a678f6a050fb0505a65e9e726996171e6dbe1547f79619eefb15/identify-2.6.14.tar.gz", hash = "sha256:663494103b4f717cb26921c52f8751363dc89db64364cd836a9bf1535f53cd6a", size = 99283, upload-time = "2025-09-06T19:30:52.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311, upload-time = "2025-10-02T17:43:40.631Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl", hash = "sha256:11a073da82212c6646b1f39bb20d4483bfb9543bd5566fec60053c4bb309bf2e", size = 99172, upload-time = "2025-09-06T19:30:51.759Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757", size = 99183, upload-time = "2025-10-02T17:43:39.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Downloading cpython-3.13.7-linux-x86_64-gnu (download) (32.0MiB)
 Downloading cpython-3.13.7-linux-x86_64-gnu (download)
Using CPython 3.13.7
Resolved 72 packages in 407ms
Updated identify v2.6.14 -> v2.6.15